### PR TITLE
set proper path to static files

### DIFF
--- a/manolo/settings/base.py
+++ b/manolo/settings/base.py
@@ -64,8 +64,8 @@ STATIC_URL = '/static/'
 
 # Additional locations of static files
 STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, '..', 'manolo/media'),
-    os.path.join(BASE_DIR, '..', 'manolo/static'),
+    os.path.join(BASE_DIR, '..', 'media'),
+    os.path.join(BASE_DIR, '..', 'manolo/assets'),
 )
 
 # List of finder classes that know how to find static files in
@@ -123,12 +123,10 @@ DJANGO_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.admin',
-
     'django.contrib.humanize',
     'bootstrap4',
     'bootstrap_themes',
     'crispy_forms',
-
     'registration',
     'rest_framework',
     'rest_framework_swagger',
@@ -256,6 +254,7 @@ SECRETS_FILE = os.path.join(BASE_DIR, '..', 'config.json')
 
 with open(SECRETS_FILE) as f:
     SECRETS = json.loads(f.read())
+
 
 def get_secret(setting, secrets=SECRETS):
     try:


### PR DESCRIPTION
Al correr collectstatic, producia errores de este tipo:

FileNotFoundError: [Errno 2] No such file or directory: '/Users/jose.valdivia/manolo/django-manolo/manolo/static'
FileNotFoundError: [Errno 2] No such file or directory: '/Users/jose.valdivia/manolo/django-manolo/manolo/media'

Este PR, actualiza los folders donde estan los static files para que pueda verse bonito el frontend
Antes:
![image](https://user-images.githubusercontent.com/5783910/94325094-12e27200-ff9d-11ea-8259-322d7b0f52e0.png)

Despues:
![image](https://user-images.githubusercontent.com/5783910/94325113-22fa5180-ff9d-11ea-87a6-38aff322d269.png)
