### PR TITLE
actualiza psycopg2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 Django==3.1.1
 pyprind==2.9.1
-psycopg2
+psycopg2-binary==2.8.6
 MarkupSafe==0.23
 Markdown==2.6.2
 Unidecode==0.4.17


### PR DESCRIPTION
psycopg2-binary no necesita compilarse para ser instalado. Eso hace posible que se instale en muchos sistemas operativos.