### PR TITLE
fixes #136 by fixing paginator

### DIFF
--- a/cazador/templates/cazador/results.html
+++ b/cazador/templates/cazador/results.html
@@ -11,9 +11,9 @@
 
     {% include "cazador/forms/search-form.html" %}
 
-    {% if paginator.object_list|length > 0 %}
+    {% if paginator.count > 0 %}
         <div class="row results-notice">
-            Manolo Cazador ha encontrado <strong>{{ paginator.object_list|length|intcomma }}</strong> resultados.
+            Manolo Cazador ha encontrado <strong>{{ paginator.count | intcomma }}</strong> resultados.
         </div>
 
         <div class="row">

--- a/manolo/templates/search/search.html
+++ b/manolo/templates/search/search.html
@@ -20,10 +20,10 @@
 
      <div id="contenido" class="container" style="max-width:1200px;">
 
-     {% if paginator.object_list|length > 0 %}
+     {% if paginator.count > 0 %}
 
        También puedes hacer búsquedas haciendo click sobre cada uno de los
-       resultados <span class="badge"><b>{{ paginator.object_list|length|intcomma }}</b></span>
+       resultados <span class="badge"><b>{{ paginator.count | intcomma }}</b></span>
 
        {% load static %}
        <p class="pull-right">


### PR DESCRIPTION
Al ver dónde se ejecutaba la consulta más pesada del request, me di cuenta que se daba en los templates, al momento de obtener el número de resultados.

De la forma en que estaba, ```paginator.object_list|length``` iba a obtener todos los objetos que iban a ser paginados (o sea, de toda la búsqueda, no solo de la página actual) y los iba a contar. En vez de hacer esto, es recomendable usar ```paginator.count```  que pasa el conteo de items a la base de datos, el cuál es hecho rápidamente (utiliza el index del primary key).

Now: ~200ms
Before: ~900ms

![image](https://user-images.githubusercontent.com/1325651/100533184-4e283980-31b6-11eb-9f12-aee685d27ee9.png)

