### PR TITLE
Evitar las urls "hardcoded"

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(r'^search.json/(?P<query>.+)/$', views.search),
-    url(r'^search.tsv/(?P<query>.+)/$', views.search_tsv),
-    url(r'^mef_captcha/$', views.mef_captcha),
+    url(r'^search.json/(?P<query>.+)/$', views.search, name='search-json'),
+    url(r'^search.tsv/(?P<query>.+)/$', views.search_tsv, name='search-tsv'),
+    url(r'^mef_captcha/$', views.mef_captcha, name='mef-captcha'),
 ]

--- a/manolo/templates/base.html
+++ b/manolo/templates/base.html
@@ -74,9 +74,9 @@
               </form>
             </li>
             <li><a href="/">Home</a></li>
-            <li><a href="/statistics/">Estadísticas</a></li>
-            <li><a href="/docs/">API</a></li>
-            <li><a href="/about/">About Manolo</a></li>
+            <li><a href="{% url 'statistics' %}">Estadísticas</a></li>
+            <li><a href="{% url 'schema-swagger-ui' %}">API</a></li>
+            <li><a href="{% url 'about' %}">About Manolo</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>

--- a/manolo/templates/search/search.html
+++ b/manolo/templates/search/search.html
@@ -27,10 +27,10 @@
 
        {% load static %}
        <p class="pull-right">
-         <a href="/api/search.tsv/{{ query }}/?page={{ page.number }}">
+         <a href="{% url 'search-tsv' query %}?page={{ page.number }}">
            <img title="Descarga datos en formato TSV" width="32px" src="{% static 'img/tsv.svg' %}" /></a>
 
-         <a href="/api/search.json/{{ query }}/?page={{ page.number }}">
+         <a href="{% url 'search-json' query %}?page={{ page.number }}">
            <img title="Descarga datos en formato JSON" width="32px" src="{% static 'img/json.svg' %}" /></a>
        </p>
 
@@ -43,7 +43,7 @@
          {% for i in page.object_list %}
            <tr>
              <td>
-               <a href='/search?q={{ i.institution }}'>
+               <a href='{% url 'search_view' %}?q={{ i.institution }}'>
                  {{ i.institution }}
                </a>
              </td>
@@ -51,31 +51,31 @@
                {{ i.date|date:"d/m/Y" }}
              </td>
              <td>
-               <a href='/search?q={{ i.full_name }}'>
+               <a href='{% url 'search_view' %}?q={{ i.full_name }}'>
                  {{ i.full_name|upper }}
                </a>
              </td>
-             <td><a href='/search?q={{ i.id_number }}'>
+             <td><a href='{% url 'search_view' %}?q={{ i.id_number }}'>
                {{ i.id_document }}: {{ i.id_number }}
              </a></td>
-             <td><a href='/search?q={{ i.entity }}'>
+             <td><a href='{% url 'search_view' %}?q={{ i.entity }}'>
                {{ i.entity }}
              </a></td>
-             <td><a href='/search?q={{ i.reason }}'>
+             <td><a href='{% url 'search_view' %}?q={{ i.reason }}'>
                {{ i.reason }}
              </a></td>
-             <td><a href='/search?q={{ i.host_name }}'>
+             <td><a href='{% url 'search_view' %}?q={{ i.host_name }}'>
                {{ i.host_name }}
              </a></td>
              {% if i.office %}
                <td>
-                 <a href='/search?q={{ i.office }}'>
+                 <a href='{% url 'search_view' %}?q={{ i.office }}'>
                    {{ i.office }}
                  </a>
                </td>
              {% else %}
                <td>
-                 <a href='/search?q={{ i.host_title }}'>
+                 <a href='{% url 'search_view' %}?q={{ i.host_title }}'>
                    {{ i.host_title }}
                  </a>
                </td>
@@ -83,13 +83,13 @@
 
              {% if i.meeting_place %}
                <td>
-                 <a href='/search?q={{ i.meeting_place }}'>
+                 <a href='{% url 'search_view' %}?q={{ i.meeting_place }}'>
                    {{ i.meeting_place }}
                  </a>
                </td>
              {% else %}
                <td>
-                 <a href='/search?q={{ i.location }}'>
+                 <a href='{% url 'search_view' %}?q={{ i.location }}'>
                    {{ i.location }}
                  </a>
                </td>

--- a/manolo/urls.py
+++ b/manolo/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
     url(r'^docs(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
     url(r'^docs/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     url(r'^redocs/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
-    url(r'^statistics/$', views.statistics),
+    url(r'^statistics/$', views.statistics, name='statistics'),
     url(r'^statistics_api/$', views.statistics_api),
 
     url(r'^about/', views.about, name='about'),


### PR DESCRIPTION
- Es una buena practica usar el tag {% url %} en vez de "hardcodear" las urls en las plantillas.
- Definir un nombre para las urls de api.urls

Nota: Este PR elimina el redireccionamiento HTTP 301 (APPEND_SLASH=True) al hacer click en los resultados de la búsqueda)