### PR TITLE
Corrige la compilacion de Travis - #164

### DIFF
--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -18,6 +18,9 @@ class TestAPI(TestCase):
                 date=datetime.date(2015, 1, 1))
             data.append(m)
         Visitor.objects.bulk_create(data)
+        # another query to update full_search explicitly since
+        # bulk_create does not invoke the save method
+        Visitor.objects.update(full_search=Visitor.get_full_search_vector())
 
         # build index with our test data
         self.maxDiff = None

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,7 +1,7 @@
 -r base.txt
 
 mock==1.0.1
-model-mommy==1.2.2
+model-mommy==2.0.0
 
 coverage
 coveralls

--- a/visitors/models.py
+++ b/visitors/models.py
@@ -106,6 +106,14 @@ class Visitor(models.Model):
     created = models.DateTimeField(auto_now_add=True, db_index=True)
     modified = models.DateTimeField(auto_now=True)
 
+    @classmethod
+    def get_full_search_vector(cls):
+        return SearchVector(
+            'full_name', 'id_number', 'host_name', 'institution',
+            'entity', 'reason', 'office', 'meeting_place', 'host_title',
+            'location'
+        )
+
     def save(self, *args, **kwargs):
         """Need to update the combined field for full text search"""
         super(Visitor, self).save(*args, **kwargs)
@@ -113,11 +121,7 @@ class Visitor(models.Model):
             Visitor.objects.filter(
                 id=self.id
             ).update(
-                full_search=SearchVector(
-                    'full_name', 'id_number', 'host_name', 'institution',
-                    'entity', 'reason', 'office', 'meeting_place', 'host_title',
-                    'location'
-                )
+                full_search=self.get_full_search_vector()
             )
 
     class Meta:


### PR DESCRIPTION
- Actualiza la version de model-mommy a 2.0.0.
- Corrige la prueba unitaria `api.tests.test_api.TestAPI.test_search_return_json_with_pagination`.

Nota: `model-mommy` ya no se mantiene y ha sido remplazado por `model-bakery` (https://pypi.org/project/model-bakery/).