### PR TITLE
Ordenar resultados por fecha, nombre, DNI e institución (corrige #74)

### DIFF
--- a/manolo/assets/css/styles.css
+++ b/manolo/assets/css/styles.css
@@ -47,3 +47,29 @@ footer {
     margin-bottom: 25px;
     text-align: center;
 }
+
+.sort-anchor {
+    display: block;
+    position: relative;
+    padding-right: 20px;
+}
+
+.sort-anchor .sort-icon,
+.sort-anchor .sort-hover-icon {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+}
+
+.sort-anchor .sort-hover-icon {
+    display: none;
+    opacity: 0.5;
+}
+
+.sort-anchor:hover .sort-icon {
+    display: none;
+}
+
+.sort-anchor:hover .sort-hover-icon {
+    display: inline-block;
+}

--- a/manolo/templates/base.html
+++ b/manolo/templates/base.html
@@ -26,7 +26,7 @@
     <link href="{% static 'css/bootstrap.min.css' %}" rel="stylesheet">
     <link href="//maxcdn.bootstrapcdn.com/bootswatch/3.2.0/readable/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="{% static 'css/styles.css' %}">
+    <link rel="stylesheet" href="{% static 'css/styles.css' %}?v=1">
 
     {% block additional_head_javascript %}
     {% endblock additional_head_javascript %}

--- a/manolo/templates/search/search.html
+++ b/manolo/templates/search/search.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load humanize %}
+{% load visitors_tags %}
 
 {% block additional_meta %}
 <meta name="robots" content="noindex">
@@ -36,9 +37,19 @@
 
        <table class='table table-hover table-striped table-bordered
          table-responsive table-condensed' style='font-size: 12px;'>
-         <th>Institución</th></th><th>Fecha</th><th>Visitante</th><th>Documento</th><th>Entidad</th>
-         <th>Motivo</th><th>Empleado público</th><th>Oficina/Cargo</th>
-         <th>Lugar de reunión</th><th>Hora ing.</th><th>Hora sal.</th>
+         <tr>
+           <th>{% sort_anchor 'institution' 'Institución' %}</th>
+           <th>{% sort_anchor 'date' 'Fecha' %}</th>
+           <th>{% sort_anchor 'full_name' 'Visitante' %}</th>
+           <th>{% sort_anchor 'id_number' 'Documento' %}</th>
+           <th>Entidad</th>
+           <th>Motivo</th>
+           <th>Empleado público</th>
+           <th>Oficina/Cargo</th>
+           <th>Lugar de reunión</th>
+           <th>Hora ing.</th>
+           <th>Hora sal.</th>
+         </tr>
 
          {% for i in page.object_list %}
            <tr>
@@ -101,40 +112,7 @@
          {% endfor %}
        </table>
 
-       {% if page.has_previous or page.has_next %}
-       <div class="text-center">
-         <nav>
-           <ul class="pagination">
-             {% if page.has_previous %}
-             <li>
-               <a aria-label="Previous" href="?q={{ query }}&amp;page={{ page.previous_page_number }}">
-                 <span aria-hidden="true">&laquo;</span>
-               </a>
-             </li>
-             {% endif %}
-
-             {% for i in page.paginator.paginate_sections %}
-               {% if page.number == i %}
-                 <li class="active"><a href="?q={{ query }}&amp;page={{ i }}">{{ i }}</a></li>
-               {% elif i == None %}
-                 <li class="disabled"><a href="#">…</a></li>
-               {% else %}
-                 <li><a href="?q={{ query }}&amp;page={{ i }}">{{ i }}</a></li>
-               {% endif %}
-             {% endfor %}
-
-             {% if page.has_next %}
-             <li>
-               <a aria-label="Next" href="?q={{ query }}&amp;page={{ page.next_page_number }}">
-                 <span aria-hidden="true">&raquo;</span>
-               </a>
-             </li>
-             {% endif %}
-
-           </ul>
-         </nav>
-       </div>
-       {% endif %}
+       {% show_pagination %}
 
      {% else %}
        <h4>No se encontraron resultados. Intenta con otra palabra clave.</h4>

--- a/manolo/templates/visitors/pagination.html
+++ b/manolo/templates/visitors/pagination.html
@@ -1,0 +1,33 @@
+{% if page.has_previous or page.has_next %}
+<div class="text-center">
+  <nav>
+    <ul class="pagination">
+      {% if page.has_previous %}
+      <li>
+        <a aria-label="Previous" href="?page={{ page.previous_page_number }}{{ getvars }}">
+          <span aria-hidden="true">&laquo;</span>
+        </a>
+      </li>
+      {% endif %}
+
+      {% for i in page.paginator.paginate_sections %}
+        {% if page.number == i %}
+        <li class="active"><a href="?page={{ i }}{{ getvars }}">{{ i }}</a></li>
+        {% elif i == None %}
+        <li class="disabled"><a href="#">…</a></li>
+        {% else %}
+        <li><a href="?page={{ i }}{{ getvars }}">{{ i }}</a></li>
+        {% endif %}
+      {% endfor %}
+
+      {% if page.has_next %}
+      <li>
+        <a aria-label="Next" href="?page={{ page.next_page_number }}{{ getvars }}">
+          <span aria-hidden="true">&raquo;</span>
+        </a>
+      </li>
+      {% endif %}
+    </ul>
+  </nav>
+</div>
+{% endif %}

--- a/manolo/templates/visitors/sort_anchor.html
+++ b/manolo/templates/visitors/sort_anchor.html
@@ -1,0 +1,1 @@
+<a href="{{ anchor_href}}" title="{{ anchor_title }}">{{ anchor_label|safe }}</a>

--- a/manolo/templates/visitors/sort_anchor.html
+++ b/manolo/templates/visitors/sort_anchor.html
@@ -1,1 +1,7 @@
-<a href="{{ anchor_href}}" title="{{ anchor_title }}">{{ anchor_label|safe }}</a>
+<a class="sort-anchor" href="{{ anchor_href }}" title="{{ anchor_title }}">
+    {{ anchor_label|safe }}
+    {% if icon %}
+    <span class="glyphicon glyphicon-{{ icon }} sort-icon" aria-hidden="true"></span>
+    {% endif %}
+    <span class="glyphicon glyphicon-{{ inverse_icon }} sort-hover-icon" aria-hidden="true"></span>
+</a>

--- a/visitors/templatetags/visitors_tags.py
+++ b/visitors/templatetags/visitors_tags.py
@@ -4,9 +4,21 @@ register = template.Library()
 
 
 SORT_DIRECTIONS = {
-    "asc": {"icon": "&uarr;", "inverse": "desc"},
-    "desc": {"icon": "&darr;", "inverse": ""},
-    "": {"icon": "", "inverse": "asc"},
+    "asc": {
+        "icon": "sort-by-attributes",
+        "inverse": "desc",
+        "inverse_icon": "sort-by-attributes-alt"
+    },
+    "desc": {
+        "icon": "sort-by-attributes-alt",
+        "inverse": "",
+        "inverse_icon": "remove-circle"
+    },
+    "": {
+        "icon": "",
+        "inverse": "asc",
+        "inverse_icon": "sort-by-attributes"
+    },
 }
 
 
@@ -79,12 +91,19 @@ def sort_anchor(context, field, title):
     else:
         sortdir = SORT_DIRECTIONS[""]
 
+    anchor_title = "Click para ordenar resultados"
+
     if sortby == field:
         getvars["dir"] = sortdir["inverse"]
         icon = sortdir["icon"]
+        inverse_icon = sortdir["inverse_icon"]
+        if sortdir["inverse"] == "":
+            anchor_title = "Click para deshabilitar el ordenamiento"
+
     else:
         getvars["dir"] = "asc"
-        icon = ""
+        icon = SORT_DIRECTIONS[""]["icon"]
+        inverse_icon = SORT_DIRECTIONS[""]["inverse_icon"]
 
     if getvars["dir"] == "":
         getvars.pop("dir", None)
@@ -94,17 +113,14 @@ def sort_anchor(context, field, title):
     else:
         urlappend = ""
 
-    if icon:
-        anchor_label = f"{title}&nbsp;{icon}"
-    else:
-        anchor_label = title
-
     if "dir" in getvars:
         anchor_href = f"?sort={field}{urlappend}"
     else:
         anchor_href = f"{'?' if urlappend else ''}{urlappend}"
     return {
-        'anchor_title': title,
-        'anchor_label': anchor_label,
-        'anchor_href': anchor_href
+        'anchor_title': anchor_title,
+        'anchor_label': title,
+        'anchor_href': anchor_href,
+        'icon': icon,
+        'inverse_icon': inverse_icon
     }

--- a/visitors/templatetags/visitors_tags.py
+++ b/visitors/templatetags/visitors_tags.py
@@ -1,0 +1,110 @@
+from django import template
+
+register = template.Library()
+
+
+SORT_DIRECTIONS = {
+    "asc": {"icon": "&uarr;", "inverse": "desc"},
+    "desc": {"icon": "&darr;", "inverse": ""},
+    "": {"icon": "", "inverse": "asc"},
+}
+
+
+@register.inclusion_tag("visitors/pagination.html", takes_context=True)
+def show_pagination(context):
+    """
+    Note: Most of this custom template tag tag has been taken from repository
+          https://github.com/ericflo/django-pagination
+
+    Render the ``visitors/pagination.html`` template.
+
+    Requires one argument, ``context``, which should be a dictionary-like data
+    structure and must contain the following keys:
+
+    ``paginator``
+        A ``Paginator`` object.
+
+    ``page``
+        This should be the result of calling the page method on the
+        previous Paginator object, given the current page.
+
+    ``request``
+        The current `HttpRequest` object. This is done by including
+        the context processor `django.template.context_processors.request`
+
+    """
+    paginator = context['paginator']
+    page = context['page']
+    getvars = context['request'].GET.copy()
+    if 'page' in getvars:
+        del getvars['page']
+    if len(getvars.keys()) > 0:
+        getvars = '&%s' % getvars.urlencode()
+    else:
+        getvars = ''
+
+    return {
+        'paginator': paginator,
+        'page': page,
+        'getvars': getvars
+    }
+
+
+@register.inclusion_tag("visitors/sort_anchor.html", takes_context=True)
+def sort_anchor(context, field, title):
+    """
+    Note: Most of this custom template tag tag has been taken from repository
+          https://github.com/webstack/webstack-django-sorting
+
+    Renders an <a> HTML tag with a link which href attribute
+    includes the field on which we sort and the direction.
+    and adds an up or down arrow if the field is the one
+    currently being sorted on.
+
+    Eg.
+        {% anchor name Name %} generates
+        <a href="?sort=name" title="Name">Name</a>
+
+    """
+    getvars = context['request'].GET.copy()
+    if "sort" in getvars:
+        sortby = getvars["sort"]
+        del getvars["sort"]
+    else:
+        sortby = ""
+
+    if "dir" in getvars:
+        sortdir = SORT_DIRECTIONS.get(getvars["dir"], SORT_DIRECTIONS[""])
+        del getvars["dir"]
+    else:
+        sortdir = SORT_DIRECTIONS[""]
+
+    if sortby == field:
+        getvars["dir"] = sortdir["inverse"]
+        icon = sortdir["icon"]
+    else:
+        getvars["dir"] = "asc"
+        icon = ""
+
+    if getvars["dir"] == "":
+        getvars.pop("dir", None)
+
+    if len(getvars.keys()) > 0:
+        urlappend = f"&{getvars.urlencode()}"
+    else:
+        urlappend = ""
+
+    if icon:
+        anchor_label = f"{title}&nbsp;{icon}"
+    else:
+        anchor_label = title
+
+    if "dir" in getvars:
+        anchor_href = f"?sort={field}{urlappend}"
+    else:
+        anchor_href = f"{'?' if urlappend else ''}{urlappend}"
+    return {
+        'anchor_title': title,
+        'anchor_label': anchor_label,
+        'anchor_href': anchor_href
+    }

--- a/visitors/utils.py
+++ b/visitors/utils.py
@@ -152,9 +152,7 @@ def get_sort_field(request):
     :return: the sorted field name, prefixed with "-" if ordering is descending
     """
     sort_direction = request.GET.get("dir")
-    print(f'dir={sort_direction}')
     field_name = (request.GET.get("sort") or "") if sort_direction else ""
-    print(f'sort={field_name}')
     sort_sign = "-" if sort_direction == "desc" else ""
     result_field = "{sign}{field}".format(sign=sort_sign, field=field_name)
     return result_field

--- a/visitors/utils.py
+++ b/visitors/utils.py
@@ -143,3 +143,18 @@ def is_dni(value: Union[str, int]) -> bool:
         return True
 
     return False
+
+
+def get_sort_field(request):
+    """
+    Retrieve field used for sorting a queryset
+    :param request: HTTP request
+    :return: the sorted field name, prefixed with "-" if ordering is descending
+    """
+    sort_direction = request.GET.get("dir")
+    print(f'dir={sort_direction}')
+    field_name = (request.GET.get("sort") or "") if sort_direction else ""
+    print(f'sort={field_name}')
+    sort_sign = "-" if sort_direction == "desc" else ""
+    result_field = "{sign}{field}".format(sign=sort_sign, field=field_name)
+    return result_field

--- a/visitors/views.py
+++ b/visitors/views.py
@@ -11,7 +11,7 @@ from rest_framework.renderers import JSONRenderer
 from django.views.decorators.csrf import csrf_exempt
 
 from visitors.models import Visitor, Statistic, Statistic_detail, Developer, VisitorScrapeProgress
-from visitors.utils import Paginator, get_user_profile
+from visitors.utils import Paginator, get_sort_field, get_user_profile
 
 
 logger = logging.getLogger(__name__)
@@ -111,6 +111,9 @@ def search(request):
             full_search=SearchQuery(query)
         )
 
+    # sort queryset
+    all_items = do_sorting(request, all_items)
+    # paginate queryset
     paginator, page = do_pagination(request, all_items)
 
     json_path = request.get_full_path() + '&json'
@@ -259,3 +262,10 @@ def do_pagination(request, all_items):
         raise Http404("No such page!")
 
     return paginator, page
+
+
+def do_sorting(request, queryset):
+    ordering = get_sort_field(request)
+    if not ordering:
+        return queryset
+    return queryset.order_by(ordering)

--- a/visitors/views.py
+++ b/visitors/views.py
@@ -267,5 +267,5 @@ def do_pagination(request, all_items):
 def do_sorting(request, queryset):
     ordering = get_sort_field(request)
     if not ordering:
-        return queryset
+        return queryset.order_by('-date')
     return queryset.order_by(ordering)


### PR DESCRIPTION
- Agrega lógica para ordenar los resultados basado en los parámetros de la url
- Refactoriza el renderizado de los enlaces de paginado en un "custom template tag" (show_pagination) para garantizar que se mantenga el "estado" incluso cuando se cambia de página.
- Implementa un "custom template tag" (sort_anchor) para renderizar el titulo de las columnas como un link que permite el ordenamiento