### PR TITLE
Actualizar robots.txt para ser entregado por el servidor web (nginx). Corrige #147

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -25,6 +25,10 @@ http {
         # Running port
         listen 80;
 
+        location /robots.txt {
+            alias /data/static/robots.txt;
+        }
+
         location /media {
             default_type application/octet-stream;
             alias /data/media;

--- a/manolo/assets/robots.txt
+++ b/manolo/assets/robots.txt
@@ -1,0 +1,3 @@
+User-Agent: *
+Disallow: /search/
+Disallow: /api/

--- a/manolo/urls.py
+++ b/manolo/urls.py
@@ -30,7 +30,6 @@ urlpatterns = [
 
     url(r'^about/', views.about, name='about'),
     path('', include('visitors.urls')),
-    path('robots.txt', views.robots_txt, name='robots'),
     url(r'^cazador/', include('cazador.urls')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 

--- a/visitors/views.py
+++ b/visitors/views.py
@@ -234,15 +234,6 @@ def api(request):
     return render(request, "api.html")
 
 
-def robots_txt(request):
-    lines = [
-        "User-Agent: *",
-        "Disallow: /search/",
-        "Disallow: /api/",
-    ]
-    return HttpResponse("\n".join(lines), content_type="text/plain")
-
-
 def do_pagination(request, all_items):
     """
     :param request: contains the current page requested by user


### PR DESCRIPTION
Actualmente `/robots.txt` esta siendo servido mediante una vista de django, lo cual puede perfectamente ser realizado por el servidor web (nginx) y asi aliviar a gunicorn


Acciones requeridas para hacer efectivo este cambio:
1. Reconstruir la imagen de docker nginx `bash docker/docker_compose build nginx`
2. Ejecutar el comando `./manage.py collecstatic`